### PR TITLE
Fix Transmission size fields to use bytes

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -3,7 +3,9 @@ module backend
 go 1.25.1
 
 require (
+	github.com/hekmon/cunits/v2 v2.1.0
 	github.com/hekmon/transmissionrpc/v3 v3.0.0
+	github.com/joho/godotenv v1.5.1
 	github.com/pocketbase/pocketbase v0.30.0
 )
 
@@ -19,9 +21,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hekmon/cunits/v2 v2.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect

--- a/server/internal/transmission/client.go
+++ b/server/internal/transmission/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hekmon/cunits/v2"
 	"github.com/hekmon/transmissionrpc/v3"
 	"github.com/pocketbase/pocketbase/core"
 )
@@ -52,10 +53,18 @@ type Client struct {
 	app    core.App
 }
 
+func bitsToBytes(bits *cunits.Bits) int64 {
+	if bits == nil {
+		return 0
+	}
+
+	return int64(uint64(*bits) / 8)
+}
+
 // NewClient creates a new Transmission client
 func NewClient(app core.App, endpoint, username, password string) (*Client, error) {
 
-    // 접속 정보 로그 출력
+	// 접속 정보 로그 출력
 	log.Printf("Connecting to transmission: host=%s, username=%s", endpoint, username)
 
 	u, err := url.Parse(endpoint)
@@ -66,7 +75,7 @@ func NewClient(app core.App, endpoint, username, password string) (*Client, erro
 		u.User = url.UserPassword(username, password)
 	}
 
-    cfg := &transmissionrpc.Config{}
+	cfg := &transmissionrpc.Config{}
 
 	client, err := transmissionrpc.New(u, cfg)
 	if err != nil {
@@ -121,9 +130,7 @@ func (c *Client) GetTorrents(ctx context.Context) ([]*TorrentData, error) {
 		if t.PercentDone != nil {
 			pctDone = *t.PercentDone
 		}
-		if t.SizeWhenDone != nil {
-			sizeDone = int64(*t.SizeWhenDone)
-		}
+		sizeDone = bitsToBytes(t.SizeWhenDone)
 		if t.RateDownload != nil {
 			rd = *t.RateDownload
 		}
@@ -136,9 +143,7 @@ func (c *Client) GetTorrents(ctx context.Context) ([]*TorrentData, error) {
 		if t.ETA != nil {
 			eta = int64(*t.ETA)
 		}
-		if t.TotalSize != nil {
-			total = int64(*t.TotalSize)
-		}
+		total = bitsToBytes(t.TotalSize)
 		if t.DownloadedEver != nil {
 			dlEver = *t.DownloadedEver
 		}
@@ -261,9 +266,7 @@ func (c *Client) AddTorrent(ctx context.Context, torrentData string, downloadDir
 	if t.PercentDone != nil {
 		pctDone = *t.PercentDone
 	}
-	if t.SizeWhenDone != nil {
-		sizeDone = int64(*t.SizeWhenDone)
-	}
+	sizeDone = bitsToBytes(t.SizeWhenDone)
 	if t.RateDownload != nil {
 		rd = *t.RateDownload
 	}
@@ -276,9 +279,7 @@ func (c *Client) AddTorrent(ctx context.Context, torrentData string, downloadDir
 	if t.ETA != nil {
 		eta = int64(*t.ETA)
 	}
-	if t.TotalSize != nil {
-		total = int64(*t.TotalSize)
-	}
+	total = bitsToBytes(t.TotalSize)
 	if t.DownloadedEver != nil {
 		dlEver = *t.DownloadedEver
 	}


### PR DESCRIPTION
## Summary
- convert Transmission torrent size fields from cunits bits into byte counts before saving or returning them
- add a helper to handle the conversion and declare the cunits module as a direct dependency

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68d21473f284832099824f0eaca81c43