### PR TITLE
fix(web): refit downloads layout actions

### DIFF
--- a/web/src/entities/downloads/components/TorrentAddDialog.tsx
+++ b/web/src/entities/downloads/components/TorrentAddDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, type ReactNode } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -14,12 +14,16 @@ import { Label } from '@shared/components/ui/label'
 import { Checkbox } from '@shared/components/ui/checkbox'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@shared/components/ui/tabs'
 import { Plus, Upload, Magnet, Loader2 } from 'lucide-react'
+import { cn } from '@shared/lib/utils'
 
 interface TorrentAddDialogProps {
   onAddTorrent: (torrent: string, options?: { downloadDir?: string; autoStart?: boolean }) => Promise<any>
+  triggerProps?: Omit<React.ComponentProps<typeof Button>, 'children'>
+  triggerLabel?: ReactNode
+  iconOnly?: boolean
 }
 
-export function TorrentAddDialog({ onAddTorrent }: TorrentAddDialogProps) {
+export function TorrentAddDialog({ onAddTorrent, triggerProps, triggerLabel, iconOnly = false }: TorrentAddDialogProps) {
   const [open, setOpen] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [activeTab, setActiveTab] = useState('magnet')
@@ -107,9 +111,19 @@ export function TorrentAddDialog({ onAddTorrent }: TorrentAddDialogProps) {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button>
-          <Plus className="h-4 w-4 mr-2" />
-          Add Torrent
+        <Button
+          {...triggerProps}
+          className={cn(
+            'bg-emerald-700 text-white shadow-lg shadow-emerald-700/20 hover:bg-emerald-600 focus-visible:ring-emerald-400',
+            triggerProps?.className
+          )}
+        >
+          <Plus className={cn('h-4 w-4', !iconOnly && 'mr-2')} />
+          {iconOnly ? (
+            <span className="sr-only">{typeof triggerLabel === 'string' ? triggerLabel : 'Add Torrent'}</span>
+          ) : (
+            triggerLabel ?? 'Add Torrent'
+          )}
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-[425px]">

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap");
 
 @custom-variant dark (&:is(.dark *));
 
@@ -116,5 +117,47 @@
   }
   body {
     @apply bg-background text-foreground;
+    font-family: 'Inter', sans-serif;
   }
+}
+
+.caption {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.43;
+}
+
+.detail {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.67;
+}
+
+.backdrop-blur-glass {
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+}
+
+.glass-panel {
+  background: rgba(255, 255, 255, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.dark .glass-panel {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.mobile-glass-panel {
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(24px) saturate(200%);
+  -webkit-backdrop-filter: blur(24px) saturate(200%);
+}
+
+.dark .mobile-glass-panel {
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.25);
 }

--- a/web/src/pages/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage.tsx
@@ -1,85 +1,196 @@
+import { useState, useCallback, useMemo, useEffect } from "react"
 import { Button } from "@shared/components/ui/button"
-import { Card } from "@shared/components/ui/card"
-import { Badge } from "@shared/components/ui/badge"
 import { Checkbox } from "@shared/components/ui/checkbox"
 import { useTorrents } from "../entities/downloads/hooks/useTorrents"
 import { DownloadItemCard } from "../entities/downloads/components/DownloadItemCard"
 import { TorrentAddDialog } from "../entities/downloads/components/TorrentAddDialog"
 import { TorrentRemoveDialog } from "../entities/downloads/components/TorrentRemoveDialog"
 import { RefreshCw, Wifi, WifiOff, Trash2, CheckSquare, Square } from "lucide-react"
-import { useState, useCallback } from "react"
+import { Tabs, TabsList, TabsTrigger } from "@shared/components/ui/tabs"
+import { useAppShell } from "@shared/contexts/AppShellContext"
+import { cn } from "@shared/lib/utils"
+import type { Torrent } from "../entities/downloads/model"
+
+type TorrentFilterKey =
+  | "all"
+  | "active"
+  | "downloading"
+  | "seeding"
+  | "checking"
+  | "paused"
+  | "finished"
+
+const TORRENT_FILTERS: Array<{
+  key: TorrentFilterKey
+  label: string
+  predicate: (torrent: Torrent) => boolean
+  hideOnMobile?: boolean
+}> = [
+  {
+    key: "all",
+    label: "All",
+    predicate: () => true,
+  },
+  {
+    key: "active",
+    label: "Active",
+    predicate: (torrent) => torrent.status === "download" || torrent.status === "seed",
+    hideOnMobile: true,
+  },
+  {
+    key: "downloading",
+    label: "Downloading",
+    predicate: (torrent) => torrent.status === "download" || torrent.status === "downloadWait",
+  },
+  {
+    key: "seeding",
+    label: "Seeding",
+    predicate: (torrent) => torrent.status === "seed" || torrent.status === "seedWait",
+    hideOnMobile: true,
+  },
+  {
+    key: "checking",
+    label: "Checking",
+    predicate: (torrent) => torrent.status === "check" || torrent.status === "checkWait",
+    hideOnMobile: true,
+  },
+  {
+    key: "paused",
+    label: "Paused",
+    predicate: (torrent) => torrent.status === "stopped",
+    hideOnMobile: true,
+  },
+  {
+    key: "finished",
+    label: "Finished",
+    predicate: (torrent) => torrent.percentDone >= 1 && torrent.status !== "download" && torrent.status !== "downloadWait",
+  },
+]
 
 export function DownloadsPage() {
   const { torrents, isLoading, error, forceSync, controlTorrent, addTorrent, removeTorrents } = useTorrents()
+  const { registerSyncControls, isMobile } = useAppShell()
+  const [activeTab, setActiveTab] = useState<TorrentFilterKey>("all")
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [showRemoveDialog, setShowRemoveDialog] = useState(false)
   const [showSelection, setShowSelection] = useState(false)
   const [removeTargets, setRemoveTargets] = useState<typeof torrents>([])
 
-  // Selection management
-  const selectedTorrents = torrents.filter(t => selectedIds.has(t.id))
-  const allSelected = torrents.length > 0 && selectedIds.size === torrents.length
-  const someSelected = selectedIds.size > 0
+  useEffect(() => {
+    registerSyncControls({
+      onSync: forceSync,
+      statusLabel: error ? "Sync issue" : "Live sync",
+      helperText: error ?? "Manual sync fetches the latest data from Transmission.",
+      tone: error ? "error" : "online",
+    })
+    return () => registerSyncControls(null)
+  }, [error, forceSync, registerSyncControls])
+
+  const filterCounts = useMemo(() => {
+    const counts = {} as Record<TorrentFilterKey, number>
+    for (const filter of TORRENT_FILTERS) {
+      counts[filter.key] = filter.key === "all" ? torrents.length : torrents.filter(filter.predicate).length
+    }
+    return counts
+  }, [torrents])
+
+  const filteredTorrents = useMemo(() => {
+    const filter = TORRENT_FILTERS.find((item) => item.key === activeTab)
+    return filter ? torrents.filter(filter.predicate) : torrents
+  }, [activeTab, torrents])
+
+  const displayedSelectedTorrents = useMemo(
+    () => filteredTorrents.filter((torrent) => selectedIds.has(torrent.id)),
+    [filteredTorrents, selectedIds]
+  )
+  const totalSelected = selectedIds.size
+  const displayedSelectedCount = displayedSelectedTorrents.length
+  const allSelected = filteredTorrents.length > 0 && displayedSelectedCount === filteredTorrents.length
+  const someDisplayedSelected = displayedSelectedCount > 0
 
   const handleSelectAll = useCallback(() => {
-    if (allSelected) {
-      setSelectedIds(new Set())
-    } else {
-      setSelectedIds(new Set(torrents.map(t => t.id)))
-    }
-  }, [allSelected, torrents])
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (allSelected) {
+        filteredTorrents.forEach((torrent) => next.delete(torrent.id))
+      } else {
+        filteredTorrents.forEach((torrent) => next.add(torrent.id))
+      }
+      return next
+    })
+  }, [allSelected, filteredTorrents])
 
   const handleSelectTorrent = useCallback((torrentId: string, selected: boolean) => {
-    const newSelected = new Set(selectedIds)
-    if (selected) {
-      newSelected.add(torrentId)
-    } else {
-      newSelected.delete(torrentId)
-    }
-    setSelectedIds(newSelected)
-  }, [selectedIds])
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (selected) {
+        next.add(torrentId)
+      } else {
+        next.delete(torrentId)
+      }
+      return next
+    })
+  }, [])
 
   const handleRemoveSelected = useCallback(() => {
-    if (selectedTorrents.length > 0) {
-      setRemoveTargets(selectedTorrents)
+    if (displayedSelectedTorrents.length > 0) {
+      setRemoveTargets(displayedSelectedTorrents)
       setShowRemoveDialog(true)
     }
-  }, [selectedTorrents])
+  }, [displayedSelectedTorrents])
 
   const handleRemoveConfirm = useCallback(async (ids: number[], deleteLocalData: boolean) => {
     await removeTorrents(ids, deleteLocalData)
-    setSelectedIds(new Set()) // Clear selection after removal
+    setSelectedIds(new Set())
     setRemoveTargets([])
     setShowRemoveDialog(false)
   }, [removeTorrents])
 
   const toggleSelectionMode = useCallback(() => {
-    setShowSelection(!showSelection)
-    if (showSelection) {
-      setSelectedIds(new Set()) // Clear selection when exiting selection mode
-    }
-  }, [showSelection])
+    setShowSelection((prev) => {
+      if (prev) {
+        setSelectedIds(new Set())
+      }
+      return !prev
+    })
+  }, [])
 
-  // Intercept item-level control to show confirmation before remove
-  const handleControl = useCallback(async (id: string, action: 'start' | 'stop' | 'remove') => {
-    if (action === 'remove') {
-      const target = torrents.find(t => t.id === id)
+  const handleControl = useCallback(async (id: string, action: "start" | "stop" | "remove") => {
+    if (action === "remove") {
+      const target = torrents.find((t) => t.id === id)
       if (target) {
         setRemoveTargets([target])
         setShowRemoveDialog(true)
       }
       return
     }
-    // Delegate start/stop
     await controlTorrent(id, action)
-  }, [torrents, controlTorrent])
+  }, [controlTorrent, torrents])
+
+  const renderEmptyState = () => (
+    <div className="px-6 py-16 text-center">
+      <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-emerald-700/10 text-emerald-700 dark:text-emerald-300">
+        <Wifi className="h-8 w-8" />
+      </div>
+      <h3 className="mt-6 text-xl font-semibold text-slate-800 dark:text-white">No torrents found</h3>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Add a torrent to get started or use the sync controls in the sidebar.
+      </p>
+      <div className="mt-6 flex justify-center">
+        <TorrentAddDialog
+          onAddTorrent={addTorrent}
+          triggerProps={{ className: "rounded-xl px-5 py-2.5 text-sm font-semibold shadow-lg shadow-emerald-700/25" }}
+        />
+      </div>
+    </div>
+  )
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-center">
-          <RefreshCw className="h-8 w-8 animate-spin mx-auto mb-4" />
-          <p className="text-muted-foreground">Loading torrents...</p>
+      <div className="flex min-h-full items-center justify-center">
+        <div className="backdrop-blur-glass glass-panel rounded-3xl border border-white/30 px-10 py-14 text-center shadow-xl dark:border-white/10">
+          <RefreshCw className="mx-auto mb-4 h-8 w-8 animate-spin text-emerald-600" />
+          <p className="text-sm text-muted-foreground">Loading torrents…</p>
         </div>
       </div>
     )
@@ -87,123 +198,132 @@ export function DownloadsPage() {
 
   if (error) {
     return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <Card className="p-6 max-w-md">
-          <div className="text-center">
-            <WifiOff className="h-8 w-8 mx-auto mb-4 text-destructive" />
-            <h3 className="font-semibold mb-2">Connection Error</h3>
-            <p className="text-sm text-muted-foreground mb-4">{error}</p>
-            <Button onClick={forceSync} variant="outline">
-              <RefreshCw className="h-4 w-4 mr-2" />
-              Retry
-            </Button>
-          </div>
-        </Card>
+      <div className="flex min-h-full items-center justify-center">
+        <div className="backdrop-blur-glass glass-panel max-w-md rounded-3xl border border-white/30 px-8 py-10 text-center shadow-xl dark:border-white/10">
+          <WifiOff className="mx-auto mb-4 h-10 w-10 text-red-500" />
+          <h3 className="text-lg font-semibold text-slate-800 dark:text-white">Connection issue</h3>
+          <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+          <Button onClick={forceSync} className="mt-6 rounded-xl bg-emerald-700 text-white hover:bg-emerald-600">
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Retry
+          </Button>
+        </div>
       </div>
     )
   }
 
   return (
-    <div className="container mx-auto p-6">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Downloads</h1>
-          <p className="text-muted-foreground">
-            Manage your torrents in real-time
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Badge variant="secondary" className="gap-1">
-            <Wifi className="h-3 w-3" />
-            Real-time
-          </Badge>
-          <Button onClick={forceSync} variant="outline" size="sm">
-            <RefreshCw className="h-4 w-4 mr-2" />
-            Sync
-          </Button>
-          <TorrentAddDialog onAddTorrent={addTorrent} />
-        </div>
-      </div>
-
-      {/* Selection controls */}
-      {torrents.length > 0 && (
-        <div className="flex items-center justify-between mb-4 p-3 bg-muted/50 rounded-lg">
-          <div className="flex items-center gap-3">
-            <Button 
-              variant="outline" 
-              size="sm" 
-              onClick={toggleSelectionMode}
-            >
-              {showSelection ? <Square className="h-4 w-4 mr-2" /> : <CheckSquare className="h-4 w-4 mr-2" />}
-              {showSelection ? 'Cancel Selection' : 'Select Torrents'}
-            </Button>
-            
-            {showSelection && (
-              <>
-                <Checkbox
-                  checked={allSelected}
-                  onCheckedChange={handleSelectAll}
-                  aria-label="Select all torrents"
+    <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-6 pb-6">
+      <div className="backdrop-blur-glass glass-panel overflow-hidden rounded-3xl border border-white/30 shadow-[0_40px_120px_-45px_rgba(15,23,42,0.45)] dark:border-white/10">
+        <div className="border-b border-white/20 px-6 py-6 dark:border-white/10">
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
+              <div className="space-y-2">
+                <h2 className="text-3xl font-semibold text-slate-800 dark:text-white">Downloads</h2>
+                <p className="caption text-muted-foreground">Real-time overview of your Transmission torrents.</p>
+              </div>
+              <div className="hidden items-center gap-3 lg:flex">
+                <TorrentAddDialog
+                  onAddTorrent={addTorrent}
+                  triggerProps={{ className: "rounded-xl px-5 py-2.5 text-sm font-semibold shadow-lg shadow-emerald-700/25" }}
                 />
-                <span className="text-sm text-muted-foreground">
-                  {selectedIds.size > 0 ? `${selectedIds.size} selected` : 'Select all'}
-                </span>
-              </>
-            )}
-          </div>
-
-          {showSelection && someSelected && (
-            <div className="flex items-center gap-2">
-              <Button 
-                variant="destructive" 
-                size="sm" 
-                onClick={handleRemoveSelected}
-              >
-                <Trash2 className="h-4 w-4 mr-2" />
-                Remove Selected ({selectedIds.size})
-              </Button>
+              </div>
             </div>
+            <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as TorrentFilterKey)} className="w-full">
+              <TabsList className="grid h-auto w-full grid-cols-3 gap-2 rounded-2xl bg-white/50 p-1 text-xs font-medium backdrop-blur-xl dark:bg-slate-900/40 lg:flex lg:w-auto lg:flex-wrap lg:gap-2 lg:rounded-full lg:px-1.5 lg:py-1.5 lg:text-sm">
+                {TORRENT_FILTERS.map((filter) => (
+                  <TabsTrigger
+                    key={filter.key}
+                    value={filter.key}
+                    className={cn(
+                      "inline-flex items-center justify-center rounded-xl px-2 py-2 transition-all data-[state=active]:bg-white data-[state=active]:text-emerald-700 dark:data-[state=active]:bg-slate-900/80 dark:data-[state=active]:text-emerald-300 lg:px-3 lg:py-1.5",
+                      filter.hideOnMobile ? "hidden lg:inline-flex" : "inline-flex"
+                    )}
+                  >
+                    <span>{filter.label}</span>
+                    <span className="ml-1 text-[11px] text-muted-foreground lg:ml-2 lg:text-xs">
+                      {filterCounts[filter.key] ?? 0}
+                    </span>
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
+          </div>
+        </div>
+
+        <div className="flex flex-col">
+          {torrents.length === 0 ? (
+            renderEmptyState()
+          ) : (
+            <>
+              {filteredTorrents.length > 0 ? (
+                <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/20 px-6 py-4 dark:border-white/10">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="rounded-xl bg-white/50 px-3 py-2 text-sm hover:bg-white/70 dark:bg-slate-900/60 dark:hover:bg-slate-900/80"
+                      onClick={toggleSelectionMode}
+                    >
+                      {showSelection ? <Square className="mr-2 h-4 w-4" /> : <CheckSquare className="mr-2 h-4 w-4" />}
+                      {showSelection ? "Cancel selection" : "Select torrents"}
+                    </Button>
+                    {showSelection && (
+                      <div className="flex items-center gap-2 rounded-xl border border-white/30 bg-white/60 px-3 py-1.5 text-xs dark:border-white/10 dark:bg-slate-900/50">
+                        <Checkbox
+                          checked={allSelected}
+                          onCheckedChange={handleSelectAll}
+                          aria-label="Select all torrents in view"
+                        />
+                        <span className="text-muted-foreground">
+                          {someDisplayedSelected ? `${displayedSelectedCount} selected` : "Select all"}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+
+                  {showSelection && someDisplayedSelected && (
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      className="rounded-xl px-4 py-2 text-sm"
+                      onClick={handleRemoveSelected}
+                    >
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      Remove selected ({displayedSelectedCount})
+                    </Button>
+                  )}
+                </div>
+              ) : (
+                <div className="border-b border-white/20 px-6 py-12 text-center text-sm text-muted-foreground dark:border-white/10">
+                  No torrents in this state yet.
+                </div>
+              )}
+
+              {filteredTorrents.length > 0 && (
+                <div className="divide-y divide-white/15 dark:divide-white/10">
+                  {filteredTorrents.map((torrent) => (
+                    <DownloadItemCard
+                      key={torrent.id}
+                      torrent={torrent}
+                      onControl={handleControl}
+                      isSelected={selectedIds.has(torrent.id)}
+                      onSelectionChange={(selected) => handleSelectTorrent(torrent.id, selected)}
+                      showSelection={showSelection}
+                    />
+                  ))}
+                </div>
+              )}
+            </>
           )}
         </div>
-      )}
-
-      {torrents.length === 0 ? (
-        <Card className="p-12 text-center">
-          <h3 className="font-semibold mb-2">No torrents found</h3>
-          <p className="text-muted-foreground mb-4">
-            Add some torrents to get started.
-          </p>
-          <div className="flex items-center justify-center gap-2">
-            <TorrentAddDialog onAddTorrent={addTorrent} />
-            <Button onClick={forceSync} variant="outline">
-              <RefreshCw className="h-4 w-4 mr-2" />
-              Check for torrents
-            </Button>
-          </div>
-        </Card>
-      ) : (
-        <div className="space-y-3">
-          {torrents.map((torrent) => (
-            <DownloadItemCard
-              key={torrent.id}
-              torrent={torrent}
-              onControl={handleControl}
-              isSelected={selectedIds.has(torrent.id)}
-              onSelectionChange={(selected) => handleSelectTorrent(torrent.id, selected)}
-              showSelection={showSelection}
-            />
-          ))}
-        </div>
-      )}
-
-      <div className="mt-8 text-center">
-        <p className="text-sm text-muted-foreground">
-          Showing {torrents.length} torrent{torrents.length !== 1 ? 's' : ''}
-          {someSelected && ` (${selectedIds.size} selected)`}
-        </p>
       </div>
 
-      {/* Remove confirmation dialog */}
+      <div className="pb-6 text-center text-sm text-muted-foreground">
+        Showing {filteredTorrents.length} of {torrents.length} torrent{torrents.length !== 1 ? "s" : ""}
+        {totalSelected > 0 && ` • ${totalSelected} selected`}
+      </div>
+
       <TorrentRemoveDialog
         open={showRemoveDialog}
         onOpenChange={(open) => {
@@ -213,6 +333,18 @@ export function DownloadsPage() {
         torrents={removeTargets}
         onRemove={handleRemoveConfirm}
       />
+
+      {isMobile && (
+        <TorrentAddDialog
+          onAddTorrent={addTorrent}
+          iconOnly
+          triggerLabel="Add torrent"
+          triggerProps={{
+            size: "icon",
+            className: "fixed bottom-6 right-6 z-40 h-14 w-14 rounded-full bg-emerald-700 text-white shadow-xl shadow-emerald-700/30 hover:bg-emerald-600 focus-visible:ring-emerald-400",
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/web/src/pages/components/AppSidebar.tsx
+++ b/web/src/pages/components/AppSidebar.tsx
@@ -1,0 +1,160 @@
+import { Download, Settings, Sun, Moon, User, RefreshCw, LogOut } from 'lucide-react'
+import { Button } from '@shared/components/ui/button'
+import { cn } from '@shared/lib/utils'
+import { Badge } from '@shared/components/ui/badge'
+import type { SyncControls } from '@shared/contexts/AppShellContext'
+
+type AppPath = '/downloads' | '/preferences'
+
+interface AppSidebarProps {
+  isDark: boolean
+  onThemeToggle: () => void
+  activePath: string
+  onNavigate: (path: AppPath) => void
+  isMobile: boolean
+  isOpen: boolean
+  onClose: () => void
+  userEmail?: string | null
+  userName?: string | null
+  syncControls: SyncControls | null
+  onLogout?: () => void
+}
+
+const menuItems: Array<{ path: AppPath; label: string; icon: typeof Download }> = [
+  { path: '/downloads', label: 'Downloads', icon: Download },
+  { path: '/preferences', label: 'Preferences', icon: Settings },
+]
+
+export function AppSidebar({
+  isDark,
+  onThemeToggle,
+  activePath,
+  onNavigate,
+  isMobile,
+  isOpen,
+  onClose,
+  userEmail,
+  userName,
+  syncControls,
+  onLogout,
+}: AppSidebarProps) {
+  const sidebarClasses = cn(
+    isMobile
+      ? 'fixed inset-y-0 left-0 z-50 w-80 transform transition-transform duration-300 ease-in-out'
+      : 'w-80',
+    isMobile && !isOpen ? '-translate-x-full' : 'translate-x-0',
+    'h-screen',
+    isMobile ? 'p-4' : 'p-3',
+    'flex flex-col'
+  )
+
+  const glassClasses = isMobile
+    ? 'backdrop-blur-glass mobile-glass-panel'
+    : 'backdrop-blur-glass glass-panel'
+
+  return (
+    <>
+      {isMobile && isOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/60"
+          onClick={onClose}
+        />
+      )}
+      <div className={sidebarClasses}>
+        <div className={cn('h-full flex flex-col rounded-2xl', glassClasses)}>
+          <div className="p-4 border-b border-border/30">
+            <div className="flex items-center gap-3 p-2 rounded-xl hover:bg-accent/30 transition-colors">
+              <div className="w-11 h-11 rounded-xl bg-emerald-700/15 flex items-center justify-center">
+                <User className="h-5 w-5 text-emerald-700 dark:text-emerald-300" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="caption truncate">{userName ?? 'Account'}</p>
+                <p className="detail text-muted-foreground truncate">{userEmail ?? 'Signed in'}</p>
+              </div>
+            </div>
+            {onLogout && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="mt-3 w-full justify-center rounded-xl text-sidebar-foreground hover:bg-accent/30"
+                onClick={onLogout}
+              >
+                <LogOut className="mr-2 h-4 w-4" />
+                <span className="caption">Logout</span>
+              </Button>
+            )}
+          </div>
+
+          <nav className="flex-1 p-4 space-y-2">
+            {menuItems.map((item) => {
+              const Icon = item.icon
+              const isActive = activePath.startsWith(item.path)
+              return (
+                <Button
+                  key={item.path}
+                  variant="ghost"
+                  className={cn(
+                    'w-full justify-start h-11 px-4 rounded-xl transition-all',
+                    isActive
+                      ? 'bg-emerald-700 text-white shadow-md hover:bg-emerald-600'
+                      : 'hover:bg-accent/40 text-sidebar-foreground'
+                  )}
+                  onClick={() => {
+                    onNavigate(item.path)
+                    if (isMobile) onClose()
+                  }}
+                >
+                  <Icon className="mr-3 h-5 w-5" />
+                  <span className="caption">{item.label}</span>
+                </Button>
+              )
+            })}
+          </nav>
+
+          <div className="mt-auto border-t border-border/30">
+            {syncControls && (
+              <div className="space-y-3 border-b border-border/30 p-4">
+                {syncControls.statusLabel && (
+                  <Badge
+                    variant="secondary"
+                    className={cn(
+                      'w-full justify-center gap-2 rounded-full bg-white/70 text-emerald-700 shadow-sm dark:bg-slate-900/60 dark:text-emerald-300',
+                      syncControls.tone === 'error' && 'bg-red-500/15 text-red-600 dark:bg-red-500/20 dark:text-red-300'
+                    )}
+                  >
+                    <RefreshCw className="h-3.5 w-3.5" />
+                    {syncControls.statusLabel}
+                  </Badge>
+                )}
+                {syncControls.helperText && (
+                  <p className="text-xs text-muted-foreground">{syncControls.helperText}</p>
+                )}
+                {syncControls.onSync && (
+                  <Button
+                    variant="ghost"
+                    className="w-full justify-center rounded-xl border border-white/30 bg-white/40 px-4 py-2 text-sm hover:bg-white/60 dark:border-white/10 dark:bg-slate-900/50 dark:hover:bg-slate-900/70"
+                    onClick={syncControls.onSync}
+                  >
+                    <RefreshCw className="mr-2 h-4 w-4" />
+                    Sync now
+                  </Button>
+                )}
+              </div>
+            )}
+            <div className="p-4">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-full justify-start h-11 px-4 rounded-xl text-sidebar-foreground hover:bg-accent/40"
+                onClick={onThemeToggle}
+              >
+                {isDark ? <Sun className="mr-3 h-5 w-5" /> : <Moon className="mr-3 h-5 w-5" />}
+                <span className="caption">{isDark ? 'Light Mode' : 'Dark Mode'}</span>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,5 +1,4 @@
 import {
-  Link,
   Outlet,
   RouterProvider,
   createRootRouteWithContext,
@@ -9,61 +8,132 @@ import {
   useRouterState,
   useNavigate,
 } from '@tanstack/react-router'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { DownloadsPage } from './pages/DownloadsPage'
 import Login from './pages/Login'
 import InitialSetup from './pages/InitialSetup'
 import Preferences from './pages/Preferences'
-import { Tabs, TabsList, TabsTrigger } from '@shared/components/ui/tabs'
 import { Button } from '@shared/components/ui/button'
-import { LogOut } from 'lucide-react'
+import { Menu } from 'lucide-react'
 import { useAuth } from '@shared/contexts/AuthContext'
 import { useAdminExists } from '@shared/hooks/useAdminExists'
 import { LoadingSpinner } from '@shared/components/LoadingSpinner'
+import { AppSidebar } from './pages/components/AppSidebar'
+import { cn } from '@shared/lib/utils'
+import { AppShellProvider } from '@shared/contexts/AppShellContext'
+import type { SyncControls } from '@shared/contexts/AppShellContext'
+
+const PAGE_TITLES: Record<string, string> = {
+  '/downloads': 'Downloads',
+  '/preferences': 'Preferences',
+}
 
 function AppLayout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const { logout, user } = useAuth()
   const navigate = useNavigate()
+  const [isDark, setIsDark] = useState(false)
+  const [isMobile, setIsMobile] = useState(false)
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [syncControls, setSyncControls] = useState<SyncControls | null>(null)
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < 1024)
+    }
+    handleResize()
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (isDark) {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+  }, [isDark])
+
+  useEffect(() => {
+    if (!isMobile) {
+      setSidebarOpen(false)
+    }
+  }, [isMobile])
+
+  const registerSyncControls = useCallback((controls: SyncControls | null) => {
+    setSyncControls(controls)
+  }, [])
 
   const handleLogout = () => {
     logout()
     navigate({ to: '/login' })
   }
 
+  const activeTitle = useMemo(() => {
+    if (pathname in PAGE_TITLES) return PAGE_TITLES[pathname]
+    const entry = Object.entries(PAGE_TITLES).find(([key]) => pathname.startsWith(key))
+    return entry?.[1] ?? 'Transmission'
+  }, [pathname])
+
+  const appShellValue = useMemo(
+    () => ({
+      isMobile,
+      registerSyncControls,
+      syncControls,
+    }),
+    [isMobile, registerSyncControls, syncControls]
+  )
+
   return (
-    <div className="dark">
-      <div className="min-h-screen bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
-        <header className="flex h-14 items-center justify-between border-b border-gray-200 px-4 dark:border-gray-800">
-          <div className="font-bold">Transmission WebUI</div>
-          {user && (
-            <div className="flex items-center gap-4">
-              <span className="text-sm text-gray-500">{user.email}</span>
-              <Button variant="ghost" size="sm" onClick={handleLogout}>
-                <LogOut className="mr-2 h-4 w-4" />
-                Logout
-              </Button>
-            </div>
-          )}
-        </header>
-
-        <div className="mx-auto max-w-5xl px-4">
-          <Tabs value={pathname} className="pt-2">
-            <TabsList>
-              <TabsTrigger value="/downloads" asChild>
-                <Link to="/downloads">Downloads</Link>
-              </TabsTrigger>
-              <TabsTrigger value="/preferences" asChild>
-                <Link to="/preferences">Preferences</Link>
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
-
-          <main className="py-6">
-            <Outlet />
-          </main>
+    <AppShellProvider value={appShellValue}>
+      <div className={cn('relative min-h-screen w-full overflow-hidden', isDark && 'dark')}>
+        <div className="pointer-events-none absolute inset-0 -z-10">
+          <div className="absolute inset-0 bg-gradient-to-br from-slate-100 via-white to-slate-200 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(34,139,34,0.12),transparent_58%)] dark:bg-[radial-gradient(circle_at_top,_rgba(34,139,34,0.28),transparent_65%)]" />
         </div>
+
+        <div className="flex min-h-screen text-foreground">
+          <AppSidebar
+            isDark={isDark}
+            onThemeToggle={() => setIsDark((prev) => !prev)}
+            activePath={pathname}
+            onNavigate={(path) => navigate({ to: path })}
+            isMobile={isMobile}
+            isOpen={!isMobile || sidebarOpen}
+            onClose={() => setSidebarOpen(false)}
+            userEmail={user?.email ?? user?.username ?? undefined}
+            userName={user?.name ?? user?.username ?? null}
+            syncControls={syncControls}
+            onLogout={handleLogout}
+          />
+
+          <div className={cn('flex-1 min-w-0 flex flex-col px-4 sm:px-6', isMobile ? 'pt-16' : 'py-10')}>
+            {isMobile && (
+              <div className="fixed top-0 left-0 right-0 z-30 flex items-center justify-center border-b border-white/20 bg-white/70 px-4 py-3 backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/80">
+                <h3 className="text-base font-semibold">{activeTitle}</h3>
+              </div>
+            )}
+
+            <main className="flex-1 min-h-0 pb-10">
+              <Outlet />
+            </main>
+          </div>
+        </div>
+
+        {isMobile && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="fixed bottom-6 left-6 z-40 h-12 w-12 rounded-full border border-white/40 bg-white/70 text-foreground shadow-lg backdrop-blur-xl hover:bg-white/80 dark:border-white/20 dark:bg-slate-900/70 dark:hover:bg-slate-900/80"
+            onClick={() => setSidebarOpen(true)}
+          >
+            <Menu className="h-5 w-5" />
+            <span className="sr-only">Open menu</span>
+          </Button>
+        )}
       </div>
-    </div>
+    </AppShellProvider>
   )
 }
 

--- a/web/src/shared/components/ui/progress.tsx
+++ b/web/src/shared/components/ui/progress.tsx
@@ -3,11 +3,16 @@ import * as ProgressPrimitive from "@radix-ui/react-progress"
 
 import { cn } from "@shared/lib/utils.ts"
 
+type ProgressProps = React.ComponentProps<typeof ProgressPrimitive.Root> & {
+  indicatorClassName?: string
+}
+
 function Progress({
   className,
   value,
+  indicatorClassName,
   ...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}: ProgressProps) {
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
@@ -19,7 +24,7 @@ function Progress({
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="bg-primary h-full w-full flex-1 transition-all"
+        className={cn("bg-primary h-full w-full flex-1 transition-all", indicatorClassName)}
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/web/src/shared/contexts/AppShellContext.tsx
+++ b/web/src/shared/contexts/AppShellContext.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, type ReactNode } from 'react'
+
+export type SyncStatusTone = 'online' | 'error' | 'idle'
+
+type SyncControls = {
+  onSync?: () => void | Promise<void>
+  statusLabel?: string
+  helperText?: string | null
+  tone?: SyncStatusTone
+}
+
+type AppShellContextValue = {
+  isMobile: boolean
+  registerSyncControls: (controls: SyncControls | null) => void
+  syncControls: SyncControls | null
+}
+
+const AppShellContext = createContext<AppShellContextValue | undefined>(undefined)
+
+export function useAppShell() {
+  const context = useContext(AppShellContext)
+  if (!context) {
+    throw new Error('useAppShell must be used within an AppShell provider')
+  }
+  return context
+}
+
+export function AppShellProvider({
+  value,
+  children,
+}: {
+  value: AppShellContextValue
+  children: ReactNode
+}) {
+  return <AppShellContext.Provider value={value}>{children}</AppShellContext.Provider>
+}
+
+export type { SyncControls }


### PR DESCRIPTION
## Summary
- introduce an app shell context so pages can register sync controls for the sidebar
- restyle the downloads experience with status tabs, filtered selection, and a mobile add torrent FAB while dropping the duplicate desktop header
- move manual sync and logout controls into the sidebar and support icon-only torrent dialog triggers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d66ef4e244832089d2a77a865c2b66