### PR TITLE
Restyle add torrent dialog with bottom sheet presentation

### DIFF
--- a/web/src/components/AddTorrentDialog.tsx
+++ b/web/src/components/AddTorrentDialog.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@shared/components/ui/dialog";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Dialog, DialogClose, DialogOverlay, DialogPortal, DialogTitle } from "@shared/components/ui/dialog";
 import { Button } from "@shared/components/ui/button";
 import { Input } from "@shared/components/ui/input";
 import { Textarea } from "@shared/components/ui/textarea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@shared/components/ui/tabs";
 import { Checkbox } from "@shared/components/ui/checkbox";
 import { Label } from "@shared/components/ui/label";
-import { Link, Upload } from "lucide-react";
+import { Link, Upload, X } from "lucide-react";
 
 interface AddTorrentDialogProps {
   open: boolean;
@@ -34,8 +35,7 @@ export function AddTorrentDialog({ open, onOpenChange, onAddTorrent }: AddTorren
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleClose = () => {
-    onOpenChange(false);
+  const resetForm = () => {
     // Reset form
     setMagnetLink('');
     setTorrentFile(null);
@@ -44,6 +44,18 @@ export function AddTorrentDialog({ open, onOpenChange, onAddTorrent }: AddTorren
     setActiveTab('magnet');
     setError(null);
     setIsSubmitting(false);
+  };
+
+  const handleClose = () => {
+    resetForm();
+    onOpenChange(false);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      resetForm();
+    }
+    onOpenChange(nextOpen);
   };
 
   const handleSubmit = async () => {
@@ -107,124 +119,142 @@ export function AddTorrentDialog({ open, onOpenChange, onAddTorrent }: AddTorren
                          (activeTab === 'file' && torrentFile);
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[500px] p-0 bg-card border-border dialog-backdrop">
-        <DialogHeader className="p-6 pb-0">
-          <DialogTitle className="text-foreground">Add New Torrent</DialogTitle>
-          <p className="caption text-muted-foreground mt-2">
-            Upload a torrent file or paste a magnet link to add a new torrent.
-          </p>
-        </DialogHeader>
-
-        <div className="px-6 pb-6">
-          <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-            <TabsList className="grid w-full grid-cols-2 mb-6">
-              <TabsTrigger value="magnet" className="flex items-center gap-2">
-                <Link className="h-4 w-4" />
-                Magnet Link
-              </TabsTrigger>
-              <TabsTrigger value="file" className="flex items-center gap-2">
-                <Upload className="h-4 w-4" />
-                Torrent File
-              </TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="magnet" className="space-y-4 mt-0">
-              <div className="space-y-2">
-                <Label className="text-foreground">Magnet Link</Label>
-                <Textarea
-                  placeholder="magnet:?xt=urn:btih:..."
-                  value={magnetLink}
-                  onChange={(e) => setMagnetLink(e.target.value)}
-                  className="min-h-[80px] resize-none bg-input border-border text-foreground placeholder:text-muted-foreground"
-                />
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogPortal>
+        <DialogOverlay className="bg-background/35 backdrop-blur-2xl transition-all data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0" />
+        <DialogPrimitive.Content
+          className="fixed inset-x-4 bottom-6 z-50 mx-auto w-[calc(100%-2rem)] max-w-xl overflow-hidden rounded-3xl border border-white/40 bg-white/35 p-0 text-foreground shadow-[0_25px_70px_-30px_rgba(15,23,42,0.75)] backdrop-blur-2xl transition-all data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-8 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-bottom-8 dark:border-white/10 dark:bg-neutral-900/60 sm:inset-x-auto sm:right-6 sm:left-auto"
+        >
+          <div className="relative overflow-hidden">
+            <div
+              className="absolute inset-0 bg-gradient-to-br from-white/60 via-white/30 to-white/10 opacity-80 dark:from-neutral-900/70 dark:via-neutral-900/40 dark:to-neutral-900/20"
+              aria-hidden="true"
+            />
+            <div className="relative">
+              <div className="flex items-start justify-between gap-4 px-6 pt-6">
+                <div>
+                  <DialogTitle className="text-lg font-semibold text-foreground">Add New Torrent</DialogTitle>
+                  <p className="caption text-muted-foreground mt-2">
+                    Upload a torrent file or paste a magnet link to add a new torrent.
+                  </p>
+                </div>
+                <DialogClose
+                  className="rounded-full border border-white/40 bg-white/60 p-1 text-muted-foreground shadow-sm transition-colors hover:bg-white/80 focus:outline-none focus:ring-2 focus:ring-white/50 dark:border-white/10 dark:bg-neutral-800/80 dark:hover:bg-neutral-700"
+                  aria-label="Close add torrent dialog"
+                >
+                  <X className="h-4 w-4" />
+                </DialogClose>
               </div>
-            </TabsContent>
 
-            <TabsContent value="file" className="space-y-4 mt-0">
-              <div className="space-y-2">
-                <Label className="text-foreground">Torrent File</Label>
-                <div className="border-2 border-dashed border-border rounded-lg p-6 text-center hover:border-border/80 transition-colors">
-                  <input
-                    type="file"
-                    accept=".torrent"
-                    onChange={handleFileChange}
-                    className="hidden"
-                    id="torrent-file"
+              <div className="px-6 pb-6 pt-4">
+                <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+                  <TabsList className="mb-6 grid w-full grid-cols-2">
+                    <TabsTrigger value="magnet" className="flex items-center gap-2">
+                      <Link className="h-4 w-4" />
+                      Magnet Link
+                    </TabsTrigger>
+                    <TabsTrigger value="file" className="flex items-center gap-2">
+                      <Upload className="h-4 w-4" />
+                      Torrent File
+                    </TabsTrigger>
+                  </TabsList>
+
+                  <TabsContent value="magnet" className="mt-0 space-y-4">
+                    <div className="space-y-2">
+                      <Label className="text-foreground">Magnet Link</Label>
+                      <Textarea
+                        placeholder="magnet:?xt=urn:btih:..."
+                        value={magnetLink}
+                        onChange={(e) => setMagnetLink(e.target.value)}
+                        className="min-h-[80px] resize-none bg-input border-border text-foreground placeholder:text-muted-foreground"
+                      />
+                    </div>
+                  </TabsContent>
+
+                  <TabsContent value="file" className="mt-0 space-y-4">
+                    <div className="space-y-2">
+                      <Label className="text-foreground">Torrent File</Label>
+                      <div className="rounded-lg border-2 border-dashed border-border p-6 text-center transition-colors hover:border-border/80">
+                        <input
+                          type="file"
+                          accept=".torrent"
+                          onChange={handleFileChange}
+                          className="hidden"
+                          id="torrent-file"
+                          disabled={isSubmitting}
+                        />
+                        <label htmlFor="torrent-file" className="flex cursor-pointer flex-col items-center gap-2">
+                          <Upload className="h-8 w-8 text-muted-foreground" />
+                          {torrentFile ? (
+                            <div className="text-center">
+                              <p className="caption text-foreground">{torrentFile.name}</p>
+                              <p className="detail text-muted-foreground">Click to change file</p>
+                            </div>
+                          ) : (
+                            <div className="text-center">
+                              <p className="caption text-foreground">Click to select torrent file</p>
+                              <p className="detail text-muted-foreground">or drag and drop</p>
+                            </div>
+                          )}
+                        </label>
+                      </div>
+                    </div>
+                  </TabsContent>
+                </Tabs>
+
+                <div className="mt-6 space-y-4">
+                  <div className="space-y-2">
+                    <Label className="text-foreground">Download Directory (Optional)</Label>
+                    <Input
+                      placeholder="/path/to/download/directory"
+                      value={downloadDirectory}
+                      onChange={(e) => setDownloadDirectory(e.target.value)}
+                      className="bg-input border-border text-foreground placeholder:text-muted-foreground"
+                      disabled={isSubmitting}
+                    />
+                  </div>
+
+                  <div className="flex items-center space-x-2">
+                    <Checkbox
+                      id="auto-start"
+                      checked={autoStart}
+                      onCheckedChange={(checked) => setAutoStart(!!checked)}
+                      disabled={isSubmitting}
+                    />
+                    <Label htmlFor="auto-start" className="cursor-pointer text-foreground">
+                      Start torrent automatically
+                    </Label>
+                  </div>
+                </div>
+
+                {error && (
+                  <div className="mt-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                    {error}
+                  </div>
+                )}
+
+                <div className="mt-6 flex justify-end gap-3">
+                  <Button
+                    variant="outline"
+                    onClick={handleClose}
+                    className="border-border text-foreground hover:bg-accent/50"
                     disabled={isSubmitting}
-                  />
-                  <label
-                    htmlFor="torrent-file"
-                    className="cursor-pointer flex flex-col items-center gap-2"
                   >
-                    <Upload className="h-8 w-8 text-muted-foreground" />
-                    {torrentFile ? (
-                      <div className="text-center">
-                        <p className="caption text-foreground">{torrentFile.name}</p>
-                        <p className="detail text-muted-foreground">Click to change file</p>
-                      </div>
-                    ) : (
-                      <div className="text-center">
-                        <p className="caption text-foreground">Click to select torrent file</p>
-                        <p className="detail text-muted-foreground">or drag and drop</p>
-                      </div>
-                    )}
-                  </label>
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={handleSubmit}
+                    disabled={!isSubmitEnabled || isSubmitting}
+                    className="bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                  >
+                    {isSubmitting ? 'Adding…' : activeTab === 'magnet' ? 'Add Magnet Link' : 'Upload File'}
+                  </Button>
                 </div>
               </div>
-            </TabsContent>
-          </Tabs>
-
-          <div className="space-y-4 mt-6">
-            <div className="space-y-2">
-              <Label className="text-foreground">Download Directory (Optional)</Label>
-              <Input
-                placeholder="/path/to/download/directory"
-                value={downloadDirectory}
-                onChange={(e) => setDownloadDirectory(e.target.value)}
-                className="bg-input border-border text-foreground placeholder:text-muted-foreground"
-                disabled={isSubmitting}
-              />
-            </div>
-
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="auto-start"
-                checked={autoStart}
-                onCheckedChange={(checked) => setAutoStart(!!checked)}
-                disabled={isSubmitting}
-              />
-              <Label htmlFor="auto-start" className="text-foreground cursor-pointer">
-                Start torrent automatically
-              </Label>
             </div>
           </div>
-
-          {error && (
-            <div className="mt-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-              {error}
-            </div>
-          )}
-
-          <div className="flex justify-end gap-3 mt-6">
-            <Button
-              variant="outline"
-              onClick={handleClose}
-              className="border-border text-foreground hover:bg-accent/50"
-              disabled={isSubmitting}
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={handleSubmit}
-              disabled={!isSubmitEnabled || isSubmitting}
-              className="bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-            >
-              {isSubmitting ? 'Adding…' : activeTab === 'magnet' ? 'Add Magnet Link' : 'Upload File'}
-            </Button>
-          </div>
-        </div>
-      </DialogContent>
+        </DialogPrimitive.Content>
+      </DialogPortal>
     </Dialog>
   );
 }


### PR DESCRIPTION
## Summary
- restyle the add torrent dialog to render as a glassmorphism bottom sheet that slides up from the bottom of the viewport
- add a custom close control and open-change handler so the form resets cleanly when the dialog closes

## Testing
- npm run lint *(fails: pre-existing lint violations around `any` usage and react-refresh exports)*

------
https://chatgpt.com/codex/tasks/task_b_68db5512953483208aa55b23465fb039