### PR TITLE
feat: support byte formatting up to petabytes

### DIFF
--- a/web/src/components/TorrentList.tsx
+++ b/web/src/components/TorrentList.tsx
@@ -9,6 +9,7 @@ import { AddTorrentDialog } from "./AddTorrentDialog";
 import { useTorrents } from "../entities/downloads/hooks/useTorrents";
 import { TorrentRemoveDialog } from "../entities/downloads/components/TorrentRemoveDialog";
 import { RefreshCw, WifiOff } from "lucide-react";
+import { formatBytes } from "@shared/lib/utils";
 
 interface TorrentListProps {
   isMobile: boolean;
@@ -19,9 +20,9 @@ const convertTorrentData = (backendTorrent: any): TorrentData => ({
   id: backendTorrent.id,
   name: backendTorrent.name,
   progress: Math.round(backendTorrent.percentDone * 100),
-  downloadSpeed: backendTorrent.rateDownload > 0 ? `${(backendTorrent.rateDownload / 1024 / 1024).toFixed(1)} MB/s` : '0 KB/s',
-  uploadSpeed: backendTorrent.rateUpload > 0 ? `${(backendTorrent.rateUpload / 1024 / 1024).toFixed(1)} MB/s` : '0 KB/s',
-  size: `${(backendTorrent.sizeWhenDone / 1024 / 1024 / 1024).toFixed(1)} GB`,
+  downloadSpeed: `${formatBytes(backendTorrent.rateDownload)}/s`,
+  uploadSpeed: `${formatBytes(backendTorrent.rateUpload)}/s`,
+  size: formatBytes(backendTorrent.sizeWhenDone),
   status: backendTorrent.status === 'download' ? 'downloading' :
           backendTorrent.status === 'seed' ? 'seeding' :
           backendTorrent.status === 'stopped' ? 'paused' : 'completed',

--- a/web/src/entities/downloads/components/DownloadItemCard.tsx
+++ b/web/src/entities/downloads/components/DownloadItemCard.tsx
@@ -3,6 +3,7 @@ import { Button } from "@shared/components/ui/button"
 import { Card } from "@shared/components/ui/card"
 import { Checkbox } from "@shared/components/ui/checkbox"
 import { Progress } from "@shared/components/ui/progress"
+import { formatBytes } from "@shared/lib/utils"
 import type {Torrent, TorrentStatus} from "../model"
 
 interface DownloadItemCardProps {
@@ -109,10 +110,3 @@ function StatusBadge({ status }: { status: TorrentStatus }) {
   )
 }
 
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return '0 B'
-  const k = 1024
-  const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
-  const i = Math.floor(Math.log(bytes) / Math.log(k))
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
-}

--- a/web/src/pages/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage.tsx
@@ -10,6 +10,7 @@ import { useTorrents } from "../entities/downloads/hooks/useTorrents"
 import { TorrentRemoveDialog } from "../entities/downloads/components/TorrentRemoveDialog"
 import { RefreshCw, WifiOff } from "lucide-react"
 import { useState, useCallback } from "react"
+import { formatBytes } from "@shared/lib/utils"
 
 // Convert backend torrent data to TorrentData format for the TorrentItem component
 const convertTorrentData = (backendTorrent: any): TorrentData => {
@@ -29,9 +30,9 @@ const convertTorrentData = (backendTorrent: any): TorrentData => {
     id: backendTorrent.id,
     name: backendTorrent.name,
     progress: Math.round(backendTorrent.percentDone * 100),
-    downloadSpeed: backendTorrent.rateDownload > 0 ? `${(backendTorrent.rateDownload / 1024 / 1024).toFixed(1)} MB/s` : '0 KB/s',
-    uploadSpeed: backendTorrent.rateUpload > 0 ? `${(backendTorrent.rateUpload / 1024 / 1024).toFixed(1)} MB/s` : '0 KB/s',
-    size: `${(backendTorrent.sizeWhenDone / 1024 / 1024 / 1024).toFixed(1)} GB`,
+    downloadSpeed: `${formatBytes(backendTorrent.rateDownload)}/s`,
+    uploadSpeed: `${formatBytes(backendTorrent.rateUpload)}/s`,
+    size: formatBytes(backendTorrent.sizeWhenDone),
     status,
     eta: backendTorrent.eta > 0 ? `${Math.round(backendTorrent.eta / 60)}m ${backendTorrent.eta % 60}s` : '∞'
   };

--- a/web/src/shared/lib/utils.ts
+++ b/web/src/shared/lib/utils.ts
@@ -30,7 +30,7 @@ export function formatBytes(bytes: number, decimals?: number): string {
       : value >= 10
         ? 1
         : 2)
-  const formattedValue = Number(value.toFixed(defaultDecimals)) * Math.sign(bytes || 1)
+  const formattedValue = Number(value.toFixed(defaultDecimals)) * Math.sign(bytes)
 
   return `${formattedValue} ${BYTE_UNITS[unitIndex]}`
 }

--- a/web/src/shared/lib/utils.ts
+++ b/web/src/shared/lib/utils.ts
@@ -1,6 +1,36 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
+const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB", "PB"] as const
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+export function formatBytes(bytes: number, decimals?: number): string {
+  if (!Number.isFinite(bytes)) {
+    return "0 B"
+  }
+
+  const absoluteBytes = Math.abs(bytes)
+  if (absoluteBytes === 0) {
+    return "0 B"
+  }
+
+  const unitIndex = Math.min(
+    Math.floor(Math.log(absoluteBytes) / Math.log(1024)),
+    BYTE_UNITS.length - 1,
+  )
+
+  const value = absoluteBytes / 1024 ** unitIndex
+  const defaultDecimals = decimals ?? (unitIndex === 0
+    ? 0
+    : value >= 100
+      ? 0
+      : value >= 10
+        ? 1
+        : 2)
+  const formattedValue = Number(value.toFixed(defaultDecimals)) * Math.sign(bytes || 1)
+
+  return `${formattedValue} ${BYTE_UNITS[unitIndex]}`
 }


### PR DESCRIPTION
## Summary
- add a shared formatBytes utility that normalizes byte values across B through PB
- reuse the formatter in torrent list and card views for size and speed display consistency

## Testing
- npm run lint *(fails: existing lint rule violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_b_68dc752de5148320866e71cd2f932ca5