### PR TITLE
fix(web): lock viewport scale

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,7 +8,10 @@
     <link rel="apple-touch-icon" sizes="192x192" href="/pwa-192x192.png" />
     <link rel="apple-touch-icon" sizes="512x512" href="/pwa-512x512.png" />
     <link rel="manifest" href="/manifest.json" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
     <meta name="theme-color" content="#111827" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />


### PR DESCRIPTION
## Summary
- prevent mobile input auto-zoom by locking the viewport scale to 1.0

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dd4d2912d483208a1696899425c692